### PR TITLE
Make output dependent on schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bower_components/
 node_modules/
 data/
 output/
+.DS_Store


### PR DESCRIPTION
# What's Changed
* The references to the CSV used to be hard-coded, now it loops through the fields defined in the schema, and handles the data dependent on their type. There's no proper error handling yet.